### PR TITLE
Update ITMAuthorizationClient for Auth Changes

### DIFF
--- a/Sources/ITwinMobile/ITMApplication.swift
+++ b/Sources/ITwinMobile/ITMApplication.swift
@@ -319,7 +319,7 @@ open class ITMApplication: NSObject, WKUIDelegate, WKNavigationDelegate {
         guard let viewController = type(of: self).topViewController else {
             return nil
         }
-        return ITMAuthorizationClient(itmApplication: self, viewController: viewController)
+        return ITMAuthorizationClient(itmApplication: self, viewController: viewController, configData: configData ?? [:])
     }
 
     /// Loads the app config JSON from the main bundle.

--- a/Sources/ITwinMobile/ITMAuthorizationClient.swift
+++ b/Sources/ITwinMobile/ITMAuthorizationClient.swift
@@ -34,12 +34,23 @@ open class ITMAuthorizationClient: NSObject, AuthorizationClient, OIDAuthStateCh
     private var currentAuthorizationFlow: OIDExternalUserAgentSession?
 
     /// Initializes and returns a newly allocated authorization client object with the specified view controller.
+    /// - Parameter itmApplication: The ``ITMApplication`` in which this ``ITMAuthorizationClient`` is being used.
     /// - Parameter viewController: The view controller in which to display the sign in Safari WebView.
-    public init(itmApplication: ITMApplication, viewController: UIViewController? = nil) {
+    /// - Parameter configData: A JSON object containing at least an `ITMAPPLICATION_CLIENT_ID` value, and optionally `ITMAPPLICATION_ISSUER_URL`, `ITMAPPLICATION_REDIRECT_URI`, and/or `ITMAPPLICATION_SCOPE` values. If `ITMAPPLICATION_CLIENT_ID` is not present this initializer will fail.
+    public init?(itmApplication: ITMApplication, viewController: UIViewController? = nil, configData: JSON) {
         self.itmApplication = itmApplication
         self.viewController = viewController
         super.init()
         registerQueryHandlers()
+        let issuerUrl = configData["ITMAPPLICATION_ISSUER_URL"] as? String ?? "https://ims.bentley.com/"
+        let clientId = configData["ITMAPPLICATION_CLIENT_ID"] as? String ?? ""
+        let redirectUrl = configData["ITMAPPLICATION_REDIRECT_URI"] as? String ?? "imodeljs://app/signin-callback"
+        let scope = configData["ITMAPPLICATION_SCOPE"] as? String ?? "email openid profile organization itwinjs"
+        authSettings = AuthSettings(issuerUrl, clientId, redirectUrl, scope, "")
+        if checkSettings() != nil {
+            return nil
+        }
+        loadState()
     }
 
     private func registerQueryHandlers() {

--- a/Sources/ITwinMobile/ITMAuthorizationClient.swift
+++ b/Sources/ITwinMobile/ITMAuthorizationClient.swift
@@ -19,6 +19,7 @@ public struct ITMAuthSettings {
     public var scope: String
 }
 
+public typealias AuthorizationClientCallback = (Error?) -> ()
 
 /// An implementation of the AuthorizationClient protocol that uses the AppAuth library to prompt the user.
 open class ITMAuthorizationClient: NSObject, AuthorizationClient, OIDAuthStateChangeDelegate, OIDAuthStateErrorDelegate {
@@ -221,7 +222,7 @@ open class ITMAuthorizationClient: NSObject, AuthorizationClient, OIDAuthStateCh
 
     /// Refreshes the user's access token.
     /// - Parameter completion: Callback to call upon success or error.
-    open func refreshAccessToken(_ completion: @escaping (Error?) -> ()) {
+    open func refreshAccessToken(_ completion: @escaping AuthorizationClientCallback) {
         guard let authState = authState else {
             sign() { error in
                 if let error = error {
@@ -253,7 +254,7 @@ open class ITMAuthorizationClient: NSObject, AuthorizationClient, OIDAuthStateCh
     ///   - clientID: The imodeljs app's clientID.
     ///   - clientSecret: The optional clientSecret.
     ///   - completion: The callback to call upon success or error.
-    open func doAuthCodeExchange(serviceConfig: OIDServiceConfiguration?, clientID: String?, clientSecret: String?, onComplete completion: @escaping (Error?) -> ()) {
+    open func doAuthCodeExchange(serviceConfig: OIDServiceConfiguration?, clientID: String?, clientSecret: String?, onComplete completion: @escaping AuthorizationClientCallback) {
         guard let authSettings = authSettings else {
             completion(error(reason: "ITMAuthorizationClient: not initialized"))
             return
@@ -431,7 +432,7 @@ open class ITMAuthorizationClient: NSObject, AuthorizationClient, OIDAuthStateCh
         }
     }
 
-    open func initialize(_ authSettings: ITMAuthSettings, onComplete completion: @escaping (Error?) -> ()) {
+    open func initialize(_ authSettings: ITMAuthSettings, onComplete completion: @escaping AuthorizationClientCallback) {
         self.authSettings = authSettings
         if let error = checkSettings() {
             completion(error)
@@ -441,7 +442,7 @@ open class ITMAuthorizationClient: NSObject, AuthorizationClient, OIDAuthStateCh
         completion(nil)
     }
 
-    open func sign(in completion: @escaping (Error?) -> ()) {
+    open func sign(in completion: @escaping AuthorizationClientCallback) {
         if let error = checkSettings() {
             completion(error)
             return
@@ -485,7 +486,7 @@ open class ITMAuthorizationClient: NSObject, AuthorizationClient, OIDAuthStateCh
         }
     }
 
-    open func signOut(_ completion: @escaping (Error?) -> ()) {
+    open func signOut(_ completion: @escaping ) {
         if let error = checkSettings() {
             completion(error)
             return

--- a/Sources/ITwinMobile/ITMAuthorizationClient.swift
+++ b/Sources/ITwinMobile/ITMAuthorizationClient.swift
@@ -486,7 +486,7 @@ open class ITMAuthorizationClient: NSObject, AuthorizationClient, OIDAuthStateCh
         }
     }
 
-    open func signOut(_ completion: @escaping ) {
+    open func signOut(_ completion: @escaping AuthorizationClientCallback) {
         if let error = checkSettings() {
             completion(error)
             return

--- a/Sources/ITwinMobile/ITMAuthorizationClient.swift
+++ b/Sources/ITwinMobile/ITMAuthorizationClient.swift
@@ -50,7 +50,6 @@ open class ITMAuthorizationClient: NSObject, AuthorizationClient, OIDAuthStateCh
         self.itmApplication = itmApplication
         self.viewController = viewController
         super.init()
-        registerQueryHandlers()
         let issuerUrl = configData["ITMAPPLICATION_ISSUER_URL"] as? String ?? "https://ims.bentley.com/"
         let clientId = configData["ITMAPPLICATION_CLIENT_ID"] as? String ?? ""
         let redirectUrl = configData["ITMAPPLICATION_REDIRECT_URI"] as? String ?? "imodeljs://app/signin-callback"
@@ -61,43 +60,6 @@ open class ITMAuthorizationClient: NSObject, AuthorizationClient, OIDAuthStateCh
             return nil
         }
         loadState()
-    }
-
-    // Used elsewhere in ITM SDK (remove?)
-    private func registerQueryHandlers() {
-        itmApplication.registerQueryHandler("Bentley_ITMAuthorizationClient_getAccessToken") { () -> Promise<String> in
-            let (promise, resolver) = Promise<String>.pending()
-            if self.itmApplication.itmMessenger.frontendLaunchDone {
-                self.getAccessToken() { token, expirationDate, error in
-                    if let error = error {
-                        resolver.reject(error)
-                    }
-                    else if let token = token {
-                        resolver.fulfill(token)
-                    } else {
-                        resolver.reject(ITMError())
-                    }
-                }
-            } else {
-                resolver.reject(ITMError())
-            }
-            return promise
-        }
-        itmApplication.registerQueryHandler("Bentley_ITMAuthorizationClient_signOut") { () -> Promise<()> in
-            let (promise, resolver) = Promise<()>.pending()
-            if self.itmApplication.itmMessenger.frontendLaunchDone {
-                self.signOut() { error in
-                    if let error = error {
-                        resolver.reject(error)
-                    } else {
-                        resolver.fulfill(())
-                    }
-                }
-            } else {
-                resolver.reject(ITMError())
-            }
-            return promise
-        }
     }
 
     /// Creates and returns an NSError object with the specified settings.


### PR DESCRIPTION
This PR should be in sync with the following PRs in imodel02 and itwinjs-core:
[Narrow the iModelJsMobile auth API](https://dev.azure.com/bentleycs/iModelTechnologies/_git/imodel02/pullrequest/244115)
[Refactor Mobile Auth](https://github.com/iTwin/itwinjs-core/pull/3571)

The AuthorizationClient protocol was updated to only require `getAccessToken`. Types that were consumed solely by ITMAuthorizationClient have been removed from iModel02.

Auth config can now be passed via the XCode project settings and should no longer be provided via TypeScript.