### PR TITLE
Update CODEOWNERS to only contain a team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 
 # These owners will be the default owners for everything in
 # the repo, unless a later match takes precedence.
-*       @toddsouthenbentley @tcobbs-bentley @Carl-Hinkle
+*       @itwin/mobilesdkadmins


### PR DESCRIPTION
Update so that @itwin/mobilesdkadmins is the only entry in CODEOWNERS.