### PR TITLE
Stop mixing Dispatch with Swift concurrency

### DIFF
--- a/Sources/ITwinMobile/ITMActionSheet.swift
+++ b/Sources/ITwinMobile/ITMActionSheet.swift
@@ -38,6 +38,8 @@ final public class ITMActionSheet: ITMNativeUIComponent {
                 // When an action is selected, this gets called before the action's handler.
                 // By running async in the main event queue, we delay processing this until
                 // after the handler has had a chance to execute.
+                // NOTE: Task { @MainActor won't work below, because we're already on the UI thread when
+                // we get here; using DispatchQueue.main.async forces the code inside to run later.
                 DispatchQueue.main.async {
                     // If no action has been selected, then the user tapped outside the popover on
                     // an iPad, OR an orientation change or window resize trigerred a cancel. This

--- a/Sources/ITwinMobile/ITMApplication.swift
+++ b/Sources/ITwinMobile/ITMApplication.swift
@@ -39,14 +39,6 @@ public extension JSON {
     }
 }
 
-
-extension Task where Success == Never, Failure == Never {
-    // Convenience so you don't have to figure out how many zeros to add to your sleep.
-    static func sleep(milliseconds: UInt64) async throws {
-        try await sleep(nanoseconds: milliseconds * 1000000)
-    }
-}
-
 // MARK: - ITMApplication class
 
 /// Main class for interacting with one iTwin Mobile web app.
@@ -396,11 +388,7 @@ open class ITMApplication: NSObject, WKUIDelegate, WKNavigationDelegate {
             // It's highly unlikely we could get here with backendLoadedContinuation nil,
             // but if we do, we need to wait for it to be initialized before continuing, or
             // nothing will work.
-            while backendLoadedContinuation == nil {
-                // Wait 10ms before trying again.
-                // Note: because our task cannot be canceled, sleep can never throw.
-                try await Task.sleep(milliseconds: 10)
-            }
+            await ITMMessenger.waitUntilReady({ self.backendLoadedContinuation != nil })
             await itmMessenger.waitUntilReady()
             IModelJsHost.sharedInstance().loadBackend(
                 backendUrl,

--- a/Sources/ITwinMobile/ITMOIDCAuthorizationClient.swift
+++ b/Sources/ITwinMobile/ITMOIDCAuthorizationClient.swift
@@ -238,7 +238,7 @@ open class ITMOIDCAuthorizationClient: NSObject, ITMAuthorizationClient, OIDAuth
                                               redirectURL: redirectUrl,
                                               responseType: OIDResponseTypeCode,
                                               additionalParameters: nil)
-        DispatchQueue.main.async {
+        Task { @MainActor in
             if let viewController = ITMApplication.topViewController {
                 // Note: The return value below is only really used by AppAuth in versions of iOS prior to iOS 11.
                 // However, even though we require iOS 12.2, if we ignore the value, it gets deleted by the system,
@@ -312,7 +312,7 @@ open class ITMOIDCAuthorizationClient: NSObject, ITMAuthorizationClient, OIDAuth
             let configuration = URLSessionConfiguration.default
             let session = URLSession(configuration: configuration)
             let postDataTask = session.dataTask(with: request) { data, response, error in
-                DispatchQueue.main.async {
+                Task { @MainActor in
                     if let error = error {
                         completion(.failure(self.error(reason: "ITMOIDCAuthorizationClient: HTTP Request failed fetching user info: \(error)")))
                         return


### PR DESCRIPTION
Also fix:

* Data race when sending messages from Swift to JS
* Typo: frontendLaunchSuceeded -> frontendLaunchSucceeded