### PR TITLE
Add support for ITMAPPLICATION_DISABLE_AUTH

### DIFF
--- a/Sources/ITwinMobile/ITMApplication.swift
+++ b/Sources/ITwinMobile/ITMApplication.swift
@@ -350,7 +350,8 @@ open class ITMApplication: NSObject, WKUIDelegate, WKNavigationDelegate {
     /// - Returns: An ``ITMOIDCAuthorizationClient`` instance configured using ``configData``.
     @MainActor
     open func createAuthClient() -> AuthorizationClient? {
-        guard let viewController = Self.topViewController else {
+        guard let viewController = Self.topViewController,
+              configData?.isYes("ITMAPPLICATION_DISABLE_AUTH") != true else {
             return nil
         }
         return ITMOIDCAuthorizationClient(itmApplication: self, viewController: viewController, configData: configData ?? [:])


### PR DESCRIPTION
Since AppAuth-iOS crashes when run in a Rosetta Simulator, allow the user to disable auth entirely so that they can still run the samples in a Rosetta Simulator.