### PR TITLE
Allow ITMLogger to be disabled

### DIFF
--- a/Sources/ITwinMobile/ITMLogger.swift
+++ b/Sources/ITwinMobile/ITMLogger.swift
@@ -7,6 +7,9 @@ import Foundation
 
 /// Default ITwinMobile logger class that uses NSLog to log messages.
 open class ITMLogger {
+    /// Set this to `false` to completely disable logging.
+    public var enabled = true
+
     public enum Severity: String {
         case fatal
         case error
@@ -40,13 +43,14 @@ open class ITMLogger {
         // do nothing, just here so it can be sub-classed
     }
 
-    /// Log a message. This default implementation uses NSLog. Replace ITMMessenger's static logger instance
-    /// with a subclass that overrides this function to change the logging behavior.
+    /// If ``enabled`` is `true`, log a message. This default implementation uses `NSLog`. Replace ITMMessenger's
+    /// static `logger` instance with a subclass that overrides this function to change the logging behavior.
     /// - Note: NSLog truncates all log messages to 1024 bytes.
     /// - Parameters:
     ///   - severity: The severity of the log message.
     ///   - logMessage: The message to log.
     open func log(_ severity: Severity?, _ logMessage: String) {
+        guard enabled else { return }
         NSLog("%@  %@", severity?.description ?? "<UNKNOWN>", logMessage)
     }
 }


### PR DESCRIPTION
Note: an `enabled` flag was also added to the Android `ITMLogger`.