### PR TITLE
Don't try to allow file URL access from webView

### DIFF
--- a/Sources/ITwinMobile/ITMApplication.swift
+++ b/Sources/ITwinMobile/ITMApplication.swift
@@ -210,8 +210,6 @@ open class ITMApplication: NSObject, WKUIDelegate, WKNavigationDelegate {
     /// - Parameter configuration: The `WKWebViewConfiguration` to set up.
     @objc open class func setupWebViewConfiguration(_ configuration: WKWebViewConfiguration) {
         configuration.userContentController = WKUserContentController()
-        configuration.preferences.setValue(true, forKey: "allowFileAccessFromFileURLs")
-        configuration.setValue(true, forKey: "allowUniversalAccessFromFileURLs")
 
         let path = getFrontendIndexPath()
         let frontendFolder = path.deletingLastPathComponent()


### PR DESCRIPTION
This is reported to crash on some unspecified future iOS version, and all iTwin Mobile-based apps should be using either the imodeljs URL scheme for running locally or the http URL scheme for running with a React debug server.