### PR TITLE
Fix leaked observers in ITMApplication

### DIFF
--- a/Sources/ITwinMobile/ITMObservers.swift
+++ b/Sources/ITwinMobile/ITMObservers.swift
@@ -6,21 +6,27 @@
 import Foundation
 
 /// Helper class to handler NotificationCenter observers that automatically remove themselves.
-class ITMObservers {
+open class ITMObservers {
     private var observers: [Any] = []
 
     deinit {
+        clear()
+    }
+
+    /// Remove all observers from the default notification center.
+    open func clear() {
         for observer in observers {
             NotificationCenter.default.removeObserver(observer)
         }
+        observers.removeAll()
     }
 
     /// Add an observer to the default notification center using `nil` for `object` and `queue`, recording the observer
-    /// for removal in `deinit`.
+    /// for removal in `deinit` or ``clear()``.
     /// - Parameters:
     ///   - name: The name of the notification to observe.
     ///   - block: The block that executes when receiving a notification.
-    func addObserver(
+    open func addObserver(
         forName name: NSNotification.Name?,
         using block: @escaping @Sendable (Notification) -> Void
     ) {

--- a/Sources/ITwinMobile/ITMViewController.swift
+++ b/Sources/ITwinMobile/ITMViewController.swift
@@ -39,10 +39,12 @@ open class ITMViewController: UIViewController {
         super.viewWillAppear(animated)
     }
 
-    /// Detaches and clears this view controller's ``ITMNativeUI``.
+    /// Detaches and clears this view controller's ``ITMNativeUI``, and detaches this view conroller from the `ITMApplication`.
+    /// - Note: This calls ``application``'s `viewWillDisappear()` function.
     open override func viewWillDisappear(_ animated: Bool) {
         itmNativeUI?.detach()
         itmNativeUI = nil
+        ITMViewController.application.viewWillDisappear()
         super.viewWillDisappear(animated)
     }
 

--- a/Sources/ITwinMobile/ITwinMobile.docc/ITwinMobile.md
+++ b/Sources/ITwinMobile/ITwinMobile.docc/ITwinMobile.md
@@ -33,6 +33,7 @@ Interaction with the API starts with the ``ITMApplication`` class. You use this 
 - ``ITMLogger``
 - ``ITMNativeUI``
 - ``ITMNativeUIComponent``
+- ``ITMObservers``
 - ``ITMOIDCAuthorizationClient``
 - ``ITMRect``
 - ``ITMSwiftUIContentView``


### PR DESCRIPTION
A user of iTwin Mobile SDK discovered that since ITMApplication is a singleton, the observers that are added in `ITMApplication.viewWillAppear` were leaking (along with the associated view controller) any time the view controller in question closed. This fixes that by having the observers have a weak reference to the view controller so that the view controller will never leak, as well as adding a new `ITMApplication.viewWillDisappear` to clean up the observers as each view controller closes (and calling that from `ITMViewController`.